### PR TITLE
feat: Add .playwright-mcp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@
 node_modules/
 /test-results/
 /playwright-report/
-/blob-report/
 /playwright/.cache/
+/.playwright-mcp/


### PR DESCRIPTION
This PR adds the /.playwright-mcp/ directory to the .gitignore file to prevent Playwright's internal cache and related files from being committed to the repository.