### PR TITLE
feat: Implement Page Object Model for login test

### DIFF
--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -1,19 +1,10 @@
 import { test, expect } from '@playwright/test';
+import { LoginPage } from './pages/LoginPage';
 
 test('login with credentials', async ({ page }) => {
-  await page.goto('/');
-
-  // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/Celonis/);
-
-  // Login
-  await page.getByLabel('Email').fill(process.env.EMAIL!);
-  await page.getByLabel('Password').fill(process.env.PASSWORD!);
-  await page.getByRole('button', { name: 'Sign in' }).click();
-
-  // Wait for the main content to load
-  await page.locator('main').waitFor();
-
-  // Add an assertion to verify successful login, for example, by checking for a specific element on the dashboard
-  await expect(page.locator('main')).toBeVisible();
+  const loginPage = new LoginPage(page);
+  await loginPage.goto();
+  await loginPage.expectPageTitle();
+  await loginPage.login(process.env.EMAIL!, process.env.PASSWORD!);
+  await loginPage.expectToBeLoggedIn();
 });

--- a/tests/pages/LoginPage.ts
+++ b/tests/pages/LoginPage.ts
@@ -1,0 +1,36 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export class LoginPage {
+  readonly page: Page;
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+  readonly signInButton: Locator;
+  readonly mainContent: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.emailInput = page.getByLabel('Email');
+    this.passwordInput = page.getByLabel('Password');
+    this.signInButton = page.getByRole('button', { name: 'Sign in' });
+    this.mainContent = page.locator('main');
+  }
+
+  async goto() {
+    await this.page.goto('/');
+  }
+
+  async login(email: string, password: string) {
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+    await this.signInButton.click();
+  }
+
+  async expectToBeLoggedIn() {
+    await this.mainContent.waitFor();
+    await expect(this.mainContent).toBeVisible();
+  }
+
+  async expectPageTitle() {
+    await expect(this.page).toHaveTitle(/Celonis/);
+  }
+}


### PR DESCRIPTION
Refactor login.spec.ts to use the Page Object Model pattern.
- Created LoginPage.ts to encapsulate login page elements and actions.
- Updated login.spec.ts to use the new LoginPage class.
- Removed unnecessary comments and formatted the code for better readability.